### PR TITLE
Chore: Connect payment to order

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -3,8 +3,8 @@ class ChargesController < ApplicationController
   end
 
   def create
-    @total_amount = 50
-    @amount = (@total_amount*100)
+    @total_amount = Order.last.total
+    @amount = @total_amount.to_i*100
 
     customer = Stripe::Customer.create(
         email: params[:stripeEmail],

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -4,7 +4,6 @@ class LandingController < ApplicationController
   end
 
   def checkout
-    @total_amount = 50
-    @total_amount = (@total_amount / 9.11).round(2)
+    @total_amount = Order.last.total
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,3 +1,7 @@
 class Order < ApplicationRecord
   acts_as_shopping_cart_using :order_item
+
+  def taxes
+    0
+  end
 end

--- a/app/views/charges/create.html.erb
+++ b/app/views/charges/create.html.erb
@@ -1,1 +1,1 @@
-<h2>Thanks, you paid <strong>$5.49</strong>!</h2>
+<h2>Thanks, you paid <strong>$<%= "%.2f" % @total_amount %></strong>!</h2>

--- a/app/views/charges/new.html.erb
+++ b/app/views/charges/new.html.erb
@@ -6,7 +6,7 @@
           </div>
       <% end %>
       <label class="amount">
-        <span>Amount: <%= @total_amount %></span>
+        <span>Amount: $<%= "%.2f" % @total_amount %></span>
       </label>
     </article>
 

--- a/app/views/dishes/index.html.erb
+++ b/app/views/dishes/index.html.erb
@@ -3,7 +3,7 @@
       <li>
         <%= dish.name.humanize %><br/>
         <%= dish.description.humanize %>
-        Price: <%= dish.price %>kr
+        Price: $<%= dish.price %>
         Ready for pick-up at <%= dish.ready_time.strftime('%H:%M') %>
         <%= dish.portions %> portions left
         <%= form_tag add_to_order_path, id: "dish-#{dish.id}" do %>

--- a/app/views/dishes/show.html.erb
+++ b/app/views/dishes/show.html.erb
@@ -1,5 +1,5 @@
 <%= @dish.name.humanize %><br/>
 <%= @dish.description.humanize %>
-Price: <%= @dish.price %>kr
+Price: $<%= @dish.price %>
 Ready for pick-up at <%= @dish.ready_time.strftime('%H:%M') %>
 <%= @dish.portions %> portions left

--- a/features/add_dish_to_order.feature
+++ b/features/add_dish_to_order.feature
@@ -6,8 +6,8 @@ Feature: Add dish to order
   Background:
     Given the following dishes exists
       | name      | description                                               | price | ready_time | portions |
-      | meatballs | homecooked with love, including mashed potatoes and sauce | 49    | 18:00      | 10       |
-      | taco      | really spicy authentic mexican tacos                      | 59    | 16:00      | 10       |
+      | meatballs | homecooked with love, including mashed potatoes and sauce |   4   | 18:00      | 10       |
+      | taco      | really spicy authentic mexican tacos                      |   5   | 16:00      | 10       |
 
   Scenario: Successfully add dish to order
     When I am on the "landing" page

--- a/features/display_dishes.feature
+++ b/features/display_dishes.feature
@@ -5,19 +5,19 @@ Feature: As a visitor,
 Background:
   Given the following dishes exists
     |    name   |                        description                              |  price  | ready_time | portions |
-    | meatballs |    homecooked with love, including mashed potatoes and sauce    |    49   |   18:00    |    10    |
-    |   taco    |    really spicy authentic mexican tacos                         |    59   |   16:00    |    10    |
+    | meatballs |    homecooked with love, including mashed potatoes and sauce    |    4    |   18:00    |    10    |
+    |   taco    |    really spicy authentic mexican tacos                         |    5    |   16:00    |    10    |
 
 Scenario: Visitor is on main page and sees dishes
   When I am on the "landing" page
   Then I should see "Meatballs"
   And I should see "Homecooked with love, including mashed potatoes and sauce"
-  And I should see "Price: 49kr"
+  And I should see "Price: $4"
   And I should see "Ready for pick-up at 18:00"
   And I should see "10 portions left"
   Then I should see "Taco"
   And I should see "Really spicy authentic mexican tacos"
-  And I should see "Price: 59kr"
+  And I should see "Price: $5"
   And I should see "Ready for pick-up at 16:00"
   And I should see "10 portions left"
 
@@ -25,6 +25,6 @@ Scenario: Visitor visits URL for certain dish
   When I am on the "Meatballs" page
   Then I should see "Meatballs"
   And I should see "Homecooked with love, including mashed potatoes and sauce"
-  And I should see "Price: 49kr"
+  And I should see "Price: $4"
   And I should see "Ready for pick-up at 18:00"
   And I should see "10 portions left"

--- a/features/payment.feature
+++ b/features/payment.feature
@@ -13,4 +13,4 @@ Feature: As a Buying User,
     And I click the stripe button
     And I fill in my card details on the stripe form
     And I submit the stripe form
-    Then I should see "Thanks, you paid $5.49!" on the order confirmation
+    Then I should see "Thanks, you paid $50.00!" on the order confirmation

--- a/features/payment.feature
+++ b/features/payment.feature
@@ -23,4 +23,4 @@ Feature: As a Buying User,
     And I click the stripe button
     And I fill in my card details on the stripe form
     And I submit the stripe form
-    Then I should see "Thanks, you paid $21.65!" on the order confirmation
+    Then I should see "Thanks, you paid $20.00!" on the order confirmation

--- a/features/payment.feature
+++ b/features/payment.feature
@@ -8,9 +8,17 @@ Feature: As a Buying User,
   In order to see which of my dishes on offer have been purchased
   I need to see payment confirmation through a payment solution
 
-  Scenario: Buying User pays for the dishes in her basket
+  Background:
+  Given the following dishes exists
+  | name      | description                                               | price | ready_time | portions |
+  | meatballs | homecooked with love, including mashed potatoes and sauce | 10    | 18:00      | 10       |
+  | taco      | really spicy authentic mexican tacos                      | 10    | 16:00      | 10       |
+
+  And there are two dishes in my order
+
+  Scenario: Buying User pays for the dishes in her order
     When I am on the "Checkout" page
     And I click the stripe button
     And I fill in my card details on the stripe form
     And I submit the stripe form
-    Then I should see "Thanks, you paid $50.00!" on the order confirmation
+    Then I should see "Thanks, you paid $20.00!" on the order confirmation

--- a/features/payment.feature
+++ b/features/payment.feature
@@ -11,8 +11,8 @@ Feature: As a Buying User,
   Background:
     Given the following dishes exists
       | name      | description                                               | price | ready_time | portions |
-      | meatballs | homecooked with love, including mashed potatoes and sauce | 10    | 18:00      | 10       |
-      | taco      | really spicy authentic mexican tacos                      | 10    | 16:00      | 10       |
+      | meatballs | homecooked with love, including mashed potatoes and sauce |  10   | 18:00      | 10       |
+      | taco      | really spicy authentic mexican tacos                      |  10   | 16:00      | 10       |
 
   Scenario: Buying User pays for the dishes in her order
     When I am on the "landing" page

--- a/features/payment.feature
+++ b/features/payment.feature
@@ -9,10 +9,10 @@ Feature: As a Buying User,
   I need to see payment confirmation through a payment solution
 
   Background:
-  Given the following dishes exists
-  | name      | description                                               | price | ready_time | portions |
-  | meatballs | homecooked with love, including mashed potatoes and sauce | 10    | 18:00      | 10       |
-  | taco      | really spicy authentic mexican tacos                      | 10    | 16:00      | 10       |
+    Given the following dishes exists
+      | name      | description                                               | price | ready_time | portions |
+      | meatballs | homecooked with love, including mashed potatoes and sauce | 10    | 18:00      | 10       |
+      | taco      | really spicy authentic mexican tacos                      | 10    | 16:00      | 10       |
 
   Scenario: Buying User pays for the dishes in her order
     When I am on the "landing" page

--- a/features/payment.feature
+++ b/features/payment.feature
@@ -14,11 +14,13 @@ Feature: As a Buying User,
   | meatballs | homecooked with love, including mashed potatoes and sauce | 10    | 18:00      | 10       |
   | taco      | really spicy authentic mexican tacos                      | 10    | 16:00      | 10       |
 
-  And there are two dishes in my order
-
   Scenario: Buying User pays for the dishes in her order
-    When I am on the "Checkout" page
+    When I am on the "landing" page
+    And I click the "Add dish" button for "taco"
+    And I click the "Add dish" button for "meatballs"
+    And there should be "2" items on the last order
+    And I am on the "Checkout" page
     And I click the stripe button
     And I fill in my card details on the stripe form
     And I submit the stripe form
-    Then I should see "Thanks, you paid $20.00!" on the order confirmation
+    Then I should see "Thanks, you paid $21.65!" on the order confirmation

--- a/features/step_definitions/add_dish_to_order_steps.rb
+++ b/features/step_definitions/add_dish_to_order_steps.rb
@@ -5,3 +5,13 @@ When(/^I click the "([^"]*)" button for "([^"]*)"$/) do |button, dish|
     click_link_or_button button
   end
 end
+
+
+And(/^there are two dishes in my order$/) do
+  %q{
+    When I am on the "landing" page
+    And I click the "Add dish" button for "taco"
+    And I click the "Add dish" button for "meatballs"
+    And there should be "2" items on the last order
+  }
+end

--- a/features/step_definitions/add_dish_to_order_steps.rb
+++ b/features/step_definitions/add_dish_to_order_steps.rb
@@ -5,13 +5,3 @@ When(/^I click the "([^"]*)" button for "([^"]*)"$/) do |button, dish|
     click_link_or_button button
   end
 end
-
-
-And(/^there are two dishes in my order$/) do
-  %q{
-    When I am on the "landing" page
-    And I click the "Add dish" button for "taco"
-    And I click the "Add dish" button for "meatballs"
-    And there should be "2" items on the last order
-  }
-end


### PR DESCRIPTION
## Pivotal Tracker story 
[https://www.pivotaltracker.com/story/show/137600617](url)

## Changes proposed in this pull request:

Successfully connects stripe payment to orders, meaning that stripe will charge the total amount of the order when you pay. 

## What I have learned working on this feature:

How to use cherry-pick and how to connect stripe with orders using act_as_shopping_cart gem helpers.

## Ready for review!
