### PR TITLE
Feature: Order confirmation page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ group :development, :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'coveralls', require: false
-  gem 'acts_as_shopping_cart', '~> 0.4.1'
   gem 'poltergeist'
   gem 'phantomjs', require: 'phantomjs/poltergeist'
   gem 'dotenv-rails'

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -3,7 +3,7 @@ class ChargesController < ApplicationController
   end
 
   def create
-    @dishes = Order.last.shopping_cart_items
+    @dishes = Order.last.shopping_cart_items.all
     @total_amount = Order.last.total
     @amount = @total_amount.to_i*100
 

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -3,6 +3,7 @@ class ChargesController < ApplicationController
   end
 
   def create
+    @dishes = Order.last.shopping_cart_items
     @total_amount = Order.last.total
     @amount = @total_amount.to_i*100
 

--- a/app/views/charges/create.html.erb
+++ b/app/views/charges/create.html.erb
@@ -1,1 +1,8 @@
-<h2>Thanks, you paid <strong>$<%= "%.2f" % @total_amount %></strong>!</h2>
+<h2>Thanks, you paid <strong>$<%= "%.2f" % @total_amount %></strong>!<br>
+  Your order:<br>
+
+  <%= @dishes.each do |dish| %>
+      <%= dish.quantity %> <%= dish.item.name.humanize %> will be ready for pick-up
+      at <%= dish.item.ready_time.strftime('%H:%M') %><br>
+  <% end %>
+</h2>

--- a/app/views/charges/create.html.erb
+++ b/app/views/charges/create.html.erb
@@ -1,7 +1,7 @@
 <h2>Thanks, you paid <strong>$<%= "%.2f" % @total_amount %></strong>!<br>
   Your order:<br>
 
-  <%= @dishes.each do |dish| %>
+  <% @dishes.each do |dish| %>
       <%= dish.quantity %> <%= dish.item.name.humanize %> will be ready for pick-up
       at <%= dish.item.ready_time.strftime('%H:%M') %><br>
   <% end %>

--- a/features/order_confirmation.feature
+++ b/features/order_confirmation.feature
@@ -19,6 +19,6 @@ Background:
     And I click the stripe button
     And I fill in my card details on the stripe form
     And I submit the stripe form
-    Then I should see "Thanks, you paid $10.00! Your Taco will be ready for pick-up at 18:00" on the order confirmation
+    Then I should see "Thanks, you paid $10.00! Your order: 1 Taco will be ready for pick-up at 16:00" on the order confirmation
 
   Scenario: User purchases two dishes with different pick_up time and is being shown pick_up time for both dishes

--- a/features/order_confirmation.feature
+++ b/features/order_confirmation.feature
@@ -1,3 +1,5 @@
+@javascript @stripe
+
 Feature:
   As a buying User,
   In order to secure the pickup of my order
@@ -14,7 +16,6 @@ Background:
     And I click the "Add dish" button for "taco"
     And there should be "1" items on the last order
     And I am on the "Checkout" page
-    And Show me an image of the page
     And I click the stripe button
     And I fill in my card details on the stripe form
     And I submit the stripe form

--- a/features/order_confirmation.feature
+++ b/features/order_confirmation.feature
@@ -1,0 +1,15 @@
+Feature:
+  As a buying User,
+  In order to secure the pickup of my order
+  I need to see a summary with location of pickup and pickup time after my payment has been confirmed
+
+Background:
+  Given the following dishes exists
+    | name      | description                                               | price | ready_time | portions |
+    | meatballs | homecooked with love, including mashed potatoes and sauce |  10   | 18:00      | 10       |
+    | taco      | really spicy authentic mexican tacos                      |  10   | 16:00      | 10       |
+
+  Scenario: User purchases a dish and is being shown pick_up time and order summary at a confirmation page
+
+
+  Scenario: User purchases two dishes with different pick_up time and is being shown pick_up time for both dishes

--- a/features/order_confirmation.feature
+++ b/features/order_confirmation.feature
@@ -19,6 +19,17 @@ Background:
     And I click the stripe button
     And I fill in my card details on the stripe form
     And I submit the stripe form
-    Then I should see "Thanks, you paid $10.00! Your order: 1 Taco will be ready for pick-up at 16:00" on the order confirmation
+    Then I should see "Thanks, you paid $10.00! Your order: 1 Taco will be ready for pick-up at 16:00" on the order confirmation page
 
   Scenario: User purchases two dishes with different pick_up time and is being shown pick_up time for both dishes
+    When I am on the "landing" page
+    And I click the "Add dish" button for "taco"
+    And I click the "Add dish" button for "meatballs"
+    And I click the "Add dish" button for "meatballs"
+    And there should be "2" items on the last order
+    And I am on the "Checkout" page
+    And I click the stripe button
+    And I fill in my card details on the stripe form
+    And I submit the stripe form
+    Then I should see "Thanks, you paid $10.00! Your order: 1 Taco will be ready for pick-up at 16:00" on the order confirmation page
+    And I should see "2 meatballs will be ready for pick-up at 16:00" on the order confirmation page

--- a/features/order_confirmation.feature
+++ b/features/order_confirmation.feature
@@ -5,11 +5,11 @@ Feature:
   In order to secure the pickup of my order
   I need to see a summary with location of pickup and pickup time after my payment has been confirmed
 
-Background:
-  Given the following dishes exists
-    | name      | description                                               | price | ready_time | portions |
-    | meatballs | homecooked with love, including mashed potatoes and sauce |  10   | 18:00      | 10       |
-    | taco      | really spicy authentic mexican tacos                      |  10   | 16:00      | 10       |
+  Background:
+    Given the following dishes exists
+      | name      | description                                               | price | ready_time | portions |
+      | meatballs | homecooked with love, including mashed potatoes and sauce | 10    | 18:00      | 10       |
+      | taco      | really spicy authentic mexican tacos                      | 10    | 16:00      | 10       |
 
   Scenario: User purchases a dish and is being shown pick_up time and order summary at a confirmation page
     When I am on the "landing" page
@@ -31,5 +31,5 @@ Background:
     And I click the stripe button
     And I fill in my card details on the stripe form
     And I submit the stripe form
-    Then I should see "Thanks, you paid $10.00! Your order: 1 Taco will be ready for pick-up at 16:00" on the order confirmation page
-    And I should see "2 meatballs will be ready for pick-up at 16:00" on the order confirmation page
+    Then I should see "Thanks, you paid $30.00! Your order: 1 Taco will be ready for pick-up at 16:00" on the order confirmation page
+    And I should see "2 Meatballs will be ready for pick-up at 18:00" on the order confirmation page

--- a/features/order_confirmation.feature
+++ b/features/order_confirmation.feature
@@ -10,6 +10,14 @@ Background:
     | taco      | really spicy authentic mexican tacos                      |  10   | 16:00      | 10       |
 
   Scenario: User purchases a dish and is being shown pick_up time and order summary at a confirmation page
-
+    When I am on the "landing" page
+    And I click the "Add dish" button for "taco"
+    And there should be "1" items on the last order
+    And I am on the "Checkout" page
+    And Show me an image of the page
+    And I click the stripe button
+    And I fill in my card details on the stripe form
+    And I submit the stripe form
+    Then I should see "Thanks, you paid $10.00! Your Taco will be ready for pick-up at 18:00" on the order confirmation
 
   Scenario: User purchases two dishes with different pick_up time and is being shown pick_up time for both dishes

--- a/features/payment.feature
+++ b/features/payment.feature
@@ -23,4 +23,4 @@ Feature: As a Buying User,
     And I click the stripe button
     And I fill in my card details on the stripe form
     And I submit the stripe form
-    Then I should see "Thanks, you paid $20.00!" on the order confirmation
+    Then I should see "Thanks, you paid $20.00!" on the order confirmation page

--- a/features/step_definitions/payment_steps.rb
+++ b/features/step_definitions/payment_steps.rb
@@ -29,6 +29,6 @@ And(/^Show me an image of the page$/) do
 end
 
 Then(/^I should see "([^"]*)" on the order confirmation$/) do |content|
-  sleep(4)
+  sleep(2)
   expect(page).to have_content content
 end

--- a/features/step_definitions/payment_steps.rb
+++ b/features/step_definitions/payment_steps.rb
@@ -28,7 +28,7 @@ And(/^Show me an image of the page$/) do
   Capybara::Screenshot.screenshot_and_open_image
 end
 
-Then(/^I should see "([^"]*)" on the order confirmation$/) do |content|
+Then(/^I should see "([^"]*)" on the order confirmation page$/) do |content|
   sleep(2)
   expect(page).to have_content content
 end

--- a/features/step_definitions/payment_steps.rb
+++ b/features/step_definitions/payment_steps.rb
@@ -16,7 +16,6 @@ When(/^I submit the stripe form$/) do
     within_frame @stripe_iframe do
       page.execute_script('$("button").click()')
     end
-    sleep(1)
 end
 
 Then(/^my order should be registered in the system$/) do
@@ -29,6 +28,5 @@ And(/^Show me an image of the page$/) do
 end
 
 Then(/^I should see "([^"]*)" on the order confirmation page$/) do |content|
-  sleep(2)
   expect(page).to have_content content
 end


### PR DESCRIPTION
## Pivotal Tracker story 
[https://www.pivotaltracker.com/story/show/137258681](url)

## Changes proposed in this pull request:

Lists all dishes in the order on the order confirmation screen. Also quantity and pick-up time. 

## What I have learned working on this feature:

That when you are looping through items with ruby in html you should not place a "=" sign when you are passing in the each loop.

## Screenshots:

<img width="543" alt="screen shot 2017-01-14 at 14 40 49" src="https://cloud.githubusercontent.com/assets/22058587/21955267/c07a8470-da67-11e6-97d3-74ac97cfbf88.png">

## Ready for review!